### PR TITLE
Added the ability to make Reaction rolls

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -657,6 +657,18 @@ export class SimpleActorSheet extends foundry.appv1.sheets.ActorSheet {
                         resolve({ advantage, disadvantage, modifier, hopeDieSize, fearDieSize });
                     }
                 },
+                rollReaction: {
+                    label: "Reaction",
+                    icon: "<i class='fas fa-dice-d12'></i>",
+                    callback: (html) => {
+                        const advantage = parseInt(html.find('#dualityDiceAdvantageInput').val()) || 0;
+                        const disadvantage = parseInt(html.find('#dualityDiceDisadvantageInput').val()) || 0;
+                        const modifier = parseInt(html.find('#dualityDiceModifierInput').val()) || 0;
+                        const hopeDieSize = html.find('#hopeDieSize').val();
+                        const fearDieSize = html.find('#fearDieSize').val();
+                        resolve({ advantage, disadvantage, modifier, hopeDieSize, fearDieSize, reaction: true });
+                    }
+                },
                 cancel: {
                     label: "Cancel",
                     callback: () => resolve(null)
@@ -699,7 +711,7 @@ export class SimpleActorSheet extends foundry.appv1.sheets.ActorSheet {
 
     if (!dialogChoice) { return; }
 
-    const { advantage, disadvantage, modifier, hopeDieSize, fearDieSize } = dialogChoice;
+    const { advantage, disadvantage, modifier, hopeDieSize, fearDieSize, reaction } = dialogChoice;
     const totalAdvantage = advantage - disadvantage;
 
     let rollType = "Normal";
@@ -740,8 +752,8 @@ export class SimpleActorSheet extends foundry.appv1.sheets.ActorSheet {
       return;
     }
 
-    const isHope = hopeDieValue > fearDieValue;
-    const isFear = hopeDieValue < fearDieValue;
+    const isHope = !reaction && hopeDieValue > fearDieValue;
+    const isFear = !reaction && hopeDieValue < fearDieValue;
 
     let finalFlavor = `<p class="roll-flavor-line"><b>${traitNamePrint}</b>${flavorSuffix}`;
     if (modifier !== 0) {

--- a/module/token.js
+++ b/module/token.js
@@ -20,6 +20,10 @@ export class SimpleTokenDocument extends TokenDocument {
   static getTrackedAttributes(data, _path=[]) {
     if ( data || _path.length ) return super.getTrackedAttributes(data, _path);
     data = {};
+    // Bail if no actor is assigned
+    if (!game?.system?.model?.Actor) {
+      return super.getTrackedAttributes(data);
+    }
     for ( const model of Object.values(game.system.model.Actor) ) {
       foundry.utils.mergeObject(data, model);
     }


### PR DESCRIPTION
In Daggerheart, reaction rolls don't generate Hope or Fear. I added a button to the roll UI and the logic necessary to handle it.

I also fixed a bug where unassigning a token's Actor would make the token throw errors and effectively become uninteractable.