### PR TITLE
Set up derived token bar fields for health, armor, and stress

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -9,8 +9,24 @@ export class SimpleActor extends Actor {
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.system.barHealth = {
+      max: this.system.health.max,
+      min: 0,
+      value: this.system.health.max - this.system.health.value
+    };
+    this.system.barStress = {
+      max: this.system.stress.max,
+      min: 0,
+      value: this.system.stress.max - this.system.stress.value
+    };
+    this.system.barArmor = {
+      max: this.system.defenses.armor.value,
+      min: 0,
+      value: this.system.defenses.armor.value - this.system.defenses['armor-slots'].value
+    }
     this.system.groups = this.system.groups || {};
     this.system.attributes = this.system.attributes || {};
+    console.log('fgsfds',this.system)
     EntitySheetHelper.clampResourceValues(this.system.attributes);
   }
 

--- a/system.json
+++ b/system.json
@@ -37,7 +37,7 @@
     "minimum": "13",
     "verified": "13"
   },
-  "primaryTokenAttribute": "health",
+  "primaryTokenAttribute": "barHealth",
   "secondaryTokenAttribute": "hope",
   "manifest": "https://raw.githubusercontent.com/featureJosh/daggerheart-swb/master/system.json",
   "download"  : "https://github.com/featureJosh/daggerheart-swb/archive/refs/tags/v2.0.8.zip"


### PR DESCRIPTION
They start full when you're at 0 marked, then they decrease as the resource is marked. This is consistent with the way the Rest Action macros seem to intend for those resources to work (0/6 is full, 6/6 is dead).